### PR TITLE
[WIP] Changing API from add to set

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -236,14 +236,16 @@ angularLocalStorage.service('localStorageService', [
 
   return {
     isSupported: browserSupportsLocalStorage,
-    add: addToLocalStorage,
+    set: addToLocalStorage, 
+    add: addToLocalStorage, //DEPRECATED
     get: getFromLocalStorage,
     remove: removeFromLocalStorage,
     clearAll: clearAllFromLocalStorage,
     stringifyJson: stringifyJson,
     parseJson: parseJson,
     cookie: {
-      add: addToCookies,
+      set: addToCookies,
+      add: addToCookies, //DEPRECATED
       get: getFromCookies,
       remove: removeFromCookies,
       clearAll: clearAllFromCookies


### PR DESCRIPTION
The current API offers a method `add` to set a value for a key. One would assume that `add` actually does add something, instead it really does set the value.

Therefor I propose to change the API (or at least change the implementation and the docs and leave the old `add` API in pleace to not break current applications).

The current PR is a work in progress, meaning that I only changed the API to offer a `set` for both the localStorage and the cookie. If this idea is accepted, I'll additionally do the following:
- Add a `setAtLocalStorage` method and using the `addToLocalStorage` as a wrapper method (again to not do a backwards compability break)
- Add a `setAtCookies` method (same as above)
- Change the docs to mention the `set` API
