### PR TITLE
Cookies made peristent

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -160,7 +160,7 @@ angularLocalStorage.service('localStorageService', [
         expiry = ", expires="+expiryDate.toGMTString();
       }
       if (!!key) {
-        document.cookie = prefix + key + "=" + encodeURIComponent(value) + expiry + ", path="+cookie.path;
+        document.cookie = prefix + key + "=" + encodeURIComponent(value) + expiry + "; path="+cookie.path;
       }
     } catch (e) {
       $rootScope.$broadcast('LocalStorageModule.notification.error',e.message);


### PR DESCRIPTION
This is a follow up on my previous cocked up pull request (accidently let IDE reformat code prior commit).
Cookies should now last the intended age (6 months default). 
And yes, it's really just one character `,` -> `;` :-)
