### PR TITLE
detecting if Json needs to be parsed or stringified as part of addToLocalStorage() and getFromLocalStorage()

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -52,6 +52,9 @@ angularLocalStorage.service('localStorageService', [
     if (typeof value == "undefined") value = null;
 
     try {
+      if (angular.isObject(value)) {
+          value = angular.toJson(value);
+      }
       localStorage.setItem(prefix+key, value);
       if (notify.setItem) {
         $rootScope.$broadcast('LocalStorageModule.notification.setitem', {key: key, newvalue: value, storageType: 'localStorage'});
@@ -73,6 +76,9 @@ angularLocalStorage.service('localStorageService', [
 
     var item = localStorage.getItem(prefix+key);
     if (!item) return null;
+    if (item.charAt(0) === "{") {
+        return angular.fromJson(item);
+    }
     return item;
   };
 


### PR DESCRIPTION
...on and toJson methods to parse it.

This saves the user from having to call the stringyfyJson() and parseJson() before getting and setting to the local storage. Those functions can also be now ported over to use angular.toJson and angular.fromJson(). That change is not included in this commit.
