### PR TITLE
Allow the prefix value to be overwritten

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -4,7 +4,7 @@ var angularLocalStorage = angular.module('LocalStorageModule', []);
 
 // You should set a prefix to avoid overwriting any local storage variables from the rest of your app
 // e.g. angularLocalStorage.constant('prefix', 'youAppName');
-angularLocalStorage.constant('prefix', 'ls');
+angularLocalStorage.value('prefix', 'ls');
 // Cookie options (usually in case of fallback)
 // expiry = Number of days before cookies expire // 0 = Does not expire
 // path = The web path the cookie represents


### PR DESCRIPTION
Changing angularLocalStorage.constant('prefix', 'ls') to angularLocalStorage.value('prefix', 'ls'). Now, this prefix can be overwritten by the consuming app.
