### PR TITLE
Fix: You can't set a cookie after you have removed another cookie

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -184,10 +184,12 @@ angularLocalStorage.service('localStorageService', [
     try {
       var expiry = '', expiryDate = new Date();
       if (value === null) {
-        cookie.expiry = -1;
+        // Mark that the cookie has expired one day ago
+        expiryDate.setTime(expiryDate.getTime() + (-1 * 24*60*60*1000));
+        expiry = "; expires="+expiryDate.toGMTString();
+
         value = '';
-      }
-      if (cookie.expiry !== 0) {
+      } else if (cookie.expiry !== 0) {
         expiryDate.setTime(expiryDate.getTime() + (cookie.expiry*24*60*60*1000));
         expiry = "; expires="+expiryDate.toGMTString();
       }


### PR DESCRIPTION
Fixed a problem where you couldn't set a cookie after you had removed another one. The problem is that we shouldn't modify the expiry field of the shared cookie object. Now we simply set the expiry date of the removed cookie without touching the shared cookie object.
