### PR TITLE
Add IIFE to avoid introducing global variables

### DIFF
--- a/localStorageModule.js
+++ b/localStorageModule.js
@@ -1,4 +1,4 @@
-
+(function() {
 /* Start angularLocalStorage */
 
 var angularLocalStorage = angular.module('LocalStorageModule', []);
@@ -258,3 +258,4 @@ angularLocalStorage.service('localStorageService', [
   };
 
 }]);
+}).call(this);


### PR DESCRIPTION
Without the closure provided by the IIFE, angularLocalStorage is a global variable.

The IIFE prevents global variable introduction.
