### PR TITLE
Add Grunt to automate testing and linting. Add Karma to run tests

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "test/lib/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+bower_components
 .tmp
 .DS_Store
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,53 @@
+module.exports = function(grunt) {
+  'use strict';
+
+  // Load the grunt tasks
+  require('load-grunt-tasks')(grunt);
+
+  // Time the grunt tasks
+  require('time-grunt')(grunt);
+
+  grunt.initConfig({
+    karma: {
+      options: {
+        autowatch: false,
+        browsers: [
+          'PhantomJS'
+        ],
+        configFile: 'test/karma.conf.js',
+        reporters: [ 'dots' ],
+        singleRun: true
+      },
+      unit: {}
+    },
+    jshint: {
+      grunt: {
+        src: [ 'Gruntfile.js' ],
+        options: {
+          node: true
+        }
+      },
+      dev: {
+        src: [ 'localStorageModule.js' ],
+        options: {
+          jshintrc: '.jshintrc',
+        }
+      },
+      test: {
+        src: [ 'test/spec/**/*.js' ],
+        options: {
+          jshintrc: 'test/.jshintrc',
+        }
+      }
+    }
+  });
+
+  grunt.registerTask('test', [
+    'karma'
+  ]);
+
+  grunt.registerTask('default', [
+    'jshint',
+    'test'
+  ]);
+};

--- a/bower.json
+++ b/bower.json
@@ -19,5 +19,9 @@
     "bower_components",
     "test",
     "tests"
-  ]
+  ],
+  "devDependencies": {
+    "angularjs": "*",
+    "angular-mocks": "~1.0.8"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Angular module that gives you access to the browsers local storage",
   "main": "localStorageModule.js",
   "scripts": {
-    "test": ""
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",
@@ -19,5 +19,15 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/grevory/angular-local-storage/issues"
+  },
+  "dependencies": {
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.9"
+  },
+  "devDependencies": {
+    "time-grunt": "~0.1.1",
+    "load-grunt-tasks": "~0.1.0",
+    "grunt-karma": "~0.6.2",
+    "grunt-contrib-jshint": "~0.6.4"
   }
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,35 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "globals": {
+    "after": false,
+    "afterEach": false,
+    "angular": false,
+    "before": false,
+    "beforeEach": false,
+    "browser": false,
+    "describe": false,
+    "expect": false,
+    "inject": false,
+    "it": false,
+    "spyOn": false
+  }
+}
+

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,49 @@
+// Karma configuration
+// http://karma-runner.github.io/0.10/config/configuration-file.html
+
+module.exports = function(config) {
+  'use strict';
+
+  var bower = 'test/lib/bower_components/';
+
+  config.set({
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '../',
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
+    browsers: ['Chrome'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      bower + 'angular/angular.js',
+      bower + 'angular-mocks/angular-mocks.js',
+      'localStorageModule.js',
+      'test/spec/**/*.js'
+    ],
+
+    // testing framework to use (jasmine/mocha/qunit/...)
+    frameworks: ['jasmine'],
+
+    // level of logging
+    // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // web server port
+    port: 8080,
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false
+  });
+};

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -1,0 +1,12 @@
+describe('Module: LocalStorageModule', function() {
+  'use strict';
+
+  // Load the Angular module
+  beforeEach(module('LocalStorageModule'));
+
+  describe('constants', function() {
+    it('reads the constants', function() {
+      expect(true).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Adds grunt to automate tasks. 

The following grunt tasks are added:

grunt jshint: lints the code. (note, this will fail until a .jshintrc file is added, like in PR https://github.com/grevory/angular-local-storage/pull/35)

grunt test: Runs karma tests

grunt: runs jshint task followed by test.

This creates a dependency on nodejs (which FE should have nowadays)
npm install and bower install are needed to install the testing dependencies.
