### PR TITLE
cookie and notify are not defined

### DIFF
--- a/angular-local-storage.js
+++ b/angular-local-storage.js
@@ -37,6 +37,9 @@ angularLocalStorage.provider('localStorageService', function(){
   this.$get = ['$rootScope', function($rootScope){
 
     var prefix = this.prefix;
+    var cookie = this.cookie;
+    var notify = this.notify;
+
     // If there is a prefix set in the config lets use that with an appended period for readability
     if (prefix.substr(-1) !== '.') {
       prefix = !!prefix ? prefix + '.' : '';


### PR DESCRIPTION
When trying to remove a cookie I noticed that the cookie wasn't being removed. Upon further inspection I saw that the function was relying on the local "cookie" variable which wasn't copied across from the initialization code. Same seems to be true for "notify".

Cookies can now be removed happily.
