### PR TITLE
Missing var

### DIFF
--- a/angular-local-storage.js
+++ b/angular-local-storage.js
@@ -295,7 +295,7 @@ angularLocalStorage.provider('localStorageService', function(){
           thisCookie = thisCookie.substring(1, thisCookie.length);
         }
 
-        key = thisCookie.substring(prefixLength, thisCookie.indexOf('='));
+        var key = thisCookie.substring(prefixLength, thisCookie.indexOf('='));
         removeFromCookies(key);
       }
     };


### PR DESCRIPTION
var keyword was missing at following line:
key = thisCookie.substring(prefixLength, thisCookie.indexOf('='));
