### PR TITLE
Check for document being in [0] key of $document

### DIFF
--- a/angular-local-storage.js
+++ b/angular-local-storage.js
@@ -75,6 +75,8 @@ angularLocalStorage.provider('localStorageService', function() {
     // When Angular's $document is not available
     if (!$document) {
       $document = document;
+    } else if ($document[0]) {
+      $document = $document[0];
     }
 
     // If there is a prefix set in the config lets use that with an appended period for readability


### PR DESCRIPTION
I have a factory that calls localStorageService.cookie.clearAll() which throws an error of `TypeError: Cannot read property 'split' of undefined`.  It turns out that this error is caused by $document having document be in `$document[0]`.  The proposed update solves my issue; thanks!
