### PR TITLE
Added package.json to bower's ignore list.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "package.json"
   ],
   "devDependencies": {
     "angularjs": "*",


### PR DESCRIPTION
In order to be able to shim this library to use it with [browserify](https://github.com/substack/node-browserify) using [browserify-shim](https://github.com/thlorenz/browserify-shim) we need to at least exclude the package.json from bower package, so browserify can look up the higher level `package.json` for browserify transforms settings.
