### PR TITLE
fixed main path to include dist folder

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "grevory <greg@gregpike.ca>"
   ],
   "description": "An Angular module that gives you access to the browser's local storage",
-  "main": "angular-local-storage.js",
+  "main": "./dist/angular-local-storage.js",
   "keywords": [
     "AngularJS",
     "Angular",


### PR DESCRIPTION
Was missing the ./dist path for referencing the main file in bower.json
