### PR TITLE
Fix main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "description": "An Angular module that gives you access to the browsers local storage",
   "homepage": "https://github.com/grevory/angular-local-storage",
-  "main": "angular-local-storage.js",
+  "main": "./dist/angular-local-storage.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
This adds the 'dist/' to the main path so Browserify can use it
