### PR TITLE
Added SourceMap option to grunt file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,7 +36,8 @@ module.exports = function(grunt) {
     },
     uglify: {
       options: {
-        banner: '<%= meta.banner %>'
+        banner: '<%= meta.banner %>',
+        sourceMap: true
       },
       dist: {
         src: ['<%= concat.dist.dest %>'],


### PR DESCRIPTION
I've added the `sourceMap: true` to the uglify task. 

Running `grunt dist` generates:

```
PS C:\Source\github\angular-local-storage> grunt dist
Running "concat:dist" (concat) task
File dist/angular-local-storage.js created.

Running "uglify:dist" (uglify) task
>> 1 sourcemap created.
>> 1 file created.

Done, without errors.


Execution Time (2014-10-17 03:33:13 UTC)
loading tasks    4ms  ■■ 2%
concat:dist     14ms  ■■■■■■■ 8%
uglify:dist    167ms  ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 90%
Total 186ms
PS C:\Source\github\angular-local-storage> git status
# On branch AddSourceMapToBuild
# Changes not staged for commit:
#   (use "git add <file>..." to update what will be committed)
#   (use "git checkout -- <file>..." to discard changes in working directory)
#
#       modified:   dist/angular-local-storage.js
#       modified:   dist/angular-local-storage.min.js
#
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#       dist/angular-local-storage.min.js.map
no changes added to commit (use "git add" and/or "git commit -a")
PS C:\Source\github\angular-local-storage>
```

Map works fine.

I didn't commit the dist changes. 