### PR TITLE
Made the private function browserSupportsCookies public, see #163.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 angular-local-storage
 =====================
 
-An Angular module that gives you access to the browsers local storage, **v0.1.3**
+An Angular module that gives you access to the browsers local storage, **v0.1.4**
 
 [![Build Status](https://secure.travis-ci.org/grevory/angular-local-storage.png?branch=master)](https://travis-ci.org/grevory/) [![Coverage Status](https://img.shields.io/coveralls/grevory/angular-local-storage.svg)](https://coveralls.io/r/grevory/angular-local-storage?branch=master)
 
@@ -27,6 +27,7 @@ An Angular module that gives you access to the browsers local storage, **v0.1.3*
  - [deriveKey](#derivekey)
  - [length](#length)
  - [cookie](#cookie)
+    - [isSupported](#cookieissupported)
     - [set](#cookieset)
     - [get](#cookieget)
     - [remove](#cookieremove)
@@ -269,6 +270,18 @@ myApp.controller('MainCtrl', function($scope, localStorageService) {
 ```
 ##Cookie
 Deal with browser's cookies directly.
+##cookie.isSupported
+Checks if cookies are enabled in the browser.
+**Returns:** `Boolean`
+```js
+myApp.controller('MainCtrl', function($scope, localStorageService) {
+  //...
+  if(localStorageService.cookie.isSupported) {
+    //...
+  }
+  //...
+});
+```
 ###cookie.set
 Directly adds a value to cookies.<br/>
 **Note:** Typically used as a fallback if local storage is not supported.<br/>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-local-storage",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "homepage": "http://gregpike.net/demos/angular-local-storage/demo.html",
   "authors": [
     "grevory <greg@gregpike.ca>"

--- a/dist/angular-local-storage.js
+++ b/dist/angular-local-storage.js
@@ -1,6 +1,6 @@
 /**
  * An Angular module that gives you access to the browsers local storage
- * @version v0.1.3 - 2014-10-30
+ * @version v0.1.4 - 2014-10-30
  * @link https://github.com/grevory/angular-local-storage
  * @author grevory <greg@gregpike.ca>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/dist/angular-local-storage.min.js
+++ b/dist/angular-local-storage.min.js
@@ -1,6 +1,6 @@
 /**
  * An Angular module that gives you access to the browsers local storage
- * @version v0.1.3 - 2014-10-30
+ * @version v0.1.4 - 2014-10-30
  * @link https://github.com/grevory/angular-local-storage
  * @author grevory <greg@gregpike.ca>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-local-storage",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "An Angular module that gives you access to the browsers local storage",
   "homepage": "https://github.com/grevory/angular-local-storage",
   "main": "./dist/angular-local-storage.js",


### PR DESCRIPTION
The function "browserSupportsCookies" is now public and accessible with localStorage.cookies.isSupported.
