### PR TITLE
Option to disable cookie fallback

### DIFF
--- a/src/angular-local-storage.js
+++ b/src/angular-local-storage.js
@@ -12,6 +12,9 @@ angularLocalStorage.provider('localStorageService', function() {
 
   // You could change web storage type localstorage or sessionStorage
   this.storageType = 'localStorage';
+  
+  // Define if cookie fallback should be used when localStorage fails
+  this.cookieFallback = true;
 
   // Cookie options (usually in case of fallback)
   // expiry = Number of days before cookies expire // 0 = Does not expire
@@ -36,6 +39,12 @@ angularLocalStorage.provider('localStorageService', function() {
    // Setter for the storageType
    this.setStorageType = function(storageType) {
      this.storageType = storageType;
+     return this;
+   };
+   
+    // Setter for the cookieFallback switch
+   this.setCookieFallback = function(cookieFallback) {
+     this.cookieFallback = !!cookieFallback;
      return this;
    };
 
@@ -121,7 +130,7 @@ angularLocalStorage.provider('localStorageService', function() {
       }
 
       // If this browser does not support local storage use cookies
-      if (!browserSupportsLocalStorage || self.storageType === 'cookie') {
+      if ((!browserSupportsLocalStorage && self.cookieFallback) || self.storageType === 'cookie') {
         if (!browserSupportsLocalStorage) {
             $rootScope.$broadcast('LocalStorageModule.notification.warning', 'LOCAL_STORAGE_NOT_SUPPORTED');
         }
@@ -139,7 +148,11 @@ angularLocalStorage.provider('localStorageService', function() {
         }
       } catch (e) {
         $rootScope.$broadcast('LocalStorageModule.notification.error', e.message);
-        return addToCookies(key, value);
+		if(self.cookieFallback) {
+          return addToCookies(key, value);
+		} else {
+		  return false;
+		}
       }
       return true;
     };


### PR DESCRIPTION
I've added an option to disable the cookie fallback when LocalStorage fails.
I simply don't want to use Cookies in my project as they don't support the amount of data and I need the return values for error handling - which are not reliable when working with the cookie fallback:

1) Cookie fallback only works when LocalStorage is completely unavailable (browser does not support it). If saving to Local Storage fails because it is full (5MB/10MB depending on browser) - the select won't go for the cookie value and return either null or the previous value from local storage.
2) Error Handling/return values seem not to work with cookies! When saving large data to cookies the browser simply ignores it and the method returns true even if it failed! LocalStorage throws the exception which gets already catched.
