### PR TITLE
Local cookies in IE11 are global.

### DIFF
--- a/src/angular-local-storage.js
+++ b/src/angular-local-storage.js
@@ -308,7 +308,7 @@ angularLocalStorage.provider('localStorageService', function() {
           expiry = "; expires=" + expiryDate.toGMTString();
         }
         if (!!key) {
-          var cookiePath = "; path=" + cookie.path;
+          var cookiePath = !!cookie.path ? "; path=" + cookie.path : "";
           if(cookie.domain){
             cookieDomain = "; domain=" + cookie.domain;
           }


### PR DESCRIPTION
Local cookies (file://...) in IE11 with path "/" are global. Setting empty path does not working.
Solution: set no path, if path is empty.