### PR TITLE
prevent double encoding of strings

### DIFF
--- a/src/angular-local-storage.js
+++ b/src/angular-local-storage.js
@@ -117,7 +117,9 @@ angularLocalStorage.provider('localStorageService', function() {
       if (isUndefined(value)) {
         value = null;
       } else {
-        value = toJson(value);
+        if (typeof(value) === 'object') {
+          value = toJson(value);
+        }
       }
 
       // If this browser does not support local storage use cookies


### PR DESCRIPTION
when saving strings with quotes ", these strings get double encoded.
this commit only converts objects to json before saving them to localstorage.