### PR TITLE
Add Angular as dependency in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,9 @@
     "tests",
     "Gruntfile.js"
   ],
+  "dependencies": {
+    "angular": "~1.x"
+  },
   "devDependencies": {
     "angular": "~1.x",
     "angular-mocks": "~1.2.1"


### PR DESCRIPTION
Adds angular as a dependency in bower.json.

Fixes #233.

This alleviates issues when using build tools like [wiredep](https://github.com/taptapship/wiredep) that order bower components based on their dependencies. Without this change it does not include angular-local-storage after angular and therefore it breaks.
