### PR TITLE
Update README.md for setStorageCookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ myApp.config(function (localStorageServiceProvider) {
 ```
 ###setStorageCookie
 Set cookie options (usually in case of fallback)<br/>
-**expiry:** number of days before cookies expire (0 = does not expire). **default:** `30`<br/>
+**expiry:** number of days before cookies expire (0 = session cookie). **default:** `30`<br/>
 **path:** the web path the cookie represents. **default:** `'/'`
 ```js
 myApp.config(function (localStorageServiceProvider) {


### PR DESCRIPTION
I have thoroughly inspected the code and confirmed that cookie expiration = 0 => session cookie and not non-expiring cookie.

This PR updates the readme to reflect this 

This may impact #269