### PR TITLE
prevent memory leak by removing listeners on the window

### DIFF
--- a/dist/angular-local-storage.js
+++ b/dist/angular-local-storage.js
@@ -1,6 +1,6 @@
 /**
  * An Angular module that gives you access to the browsers local storage
- * @version v0.4.0 - 2016-08-17
+ * @version v0.4.0 - 2016-08-26
  * @link https://github.com/grevory/angular-local-storage
  * @author grevory <greg@gregpike.ca>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -476,9 +476,16 @@ angular
         if (browserSupportsLocalStorage) {
             if ($window.addEventListener) {
                 $window.addEventListener("storage", handleStorageChangeCallback, false);
+                $rootScope.$on('$destroy', function() {
+                  $window.removeEventListener("storage", handleStorageChangeCallback);
+                });
             } else if($window.attachEvent){
+                // attachEvent and detachEvent are proprietary to IE v6-10
                 $window.attachEvent("onstorage", handleStorageChangeCallback);
-            };
+                $rootScope.$on('$destroy', function() {
+                  $window.detachEvent("onstorage", handleStorageChangeCallback);
+                });
+            }
         }
 
         // Callback handler for storage changed.

--- a/src/angular-local-storage.js
+++ b/src/angular-local-storage.js
@@ -468,9 +468,16 @@ angular
         if (browserSupportsLocalStorage) {
             if ($window.addEventListener) {
                 $window.addEventListener("storage", handleStorageChangeCallback, false);
+                $rootScope.$on('$destroy', function() {
+                    $window.removeEventListener("storage", handleStorageChangeCallback);
+                });
             } else if($window.attachEvent){
+                // attachEvent and detachEvent are proprietary to IE v6-10
                 $window.attachEvent("onstorage", handleStorageChangeCallback);
-            };
+                $rootScope.$on('$destroy', function() {
+                    $window.detachEvent("onstorage", handleStorageChangeCallback);
+                });
+            }
         }
 
         // Callback handler for storage changed.

--- a/test/spec/localStorageSpec.js
+++ b/test/spec/localStorageSpec.js
@@ -779,10 +779,13 @@ describe('localStorageService', function () {
     describe('localStorageChanged', function () {
         var listeners = {};
         beforeEach(module('LocalStorageModule', function ($provide) {
-            var window = jasmine.createSpyObj('$window', ['addEventListener']);
+            var window = jasmine.createSpyObj('$window', ['addEventListener','removeEventListener']);
             window.localStorage = localStorageMock();
             window.addEventListener.and.callFake(function (event, listener) {
                 listeners[event] = listener;
+            });
+            window.removeEventListener.and.callFake(function (event) {
+                listeners[event] = null;
             });
             $provide.value('$window', window);
             $provide.value('$timeout', function (fn) { fn(); });


### PR DESCRIPTION
I am using this library in a project that has about 2500 unit tests written with Jasmine and run via karma, grunt and PhantomJS.  After upgrading the library to v0.2.8 (from v0.1.3) there was significantly more memory consumed by PhantomJS - it went from to 250MB to over 1GB therefore causing PhantomJS to crash.

I was able to track the issue down to these few lines of code:
The handleStorageChangeCallback has a reference to $rootScope in order to broadcast the event.  Therefore when $rootScope is destroyed it will remain in memory unless the listener is removed from the $window. 

I can provide more detail if needed, just let me know